### PR TITLE
Add ex_machina by default

### DIFF
--- a/template/$PROJECT_NAME$/mix.exs
+++ b/template/$PROJECT_NAME$/mix.exs
@@ -35,7 +35,8 @@ defmodule <%= @project_name_camel_case %>.Mixfile do
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
      {:guardian, "~> 0.14.4"},
-     {:comeonin, "~> 3.0.0"}]
+     {:comeonin, "~> 3.0.0"},
+     {:ex_machina, "~> 2.0", only: :test}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/template/$PROJECT_NAME$/test/support/conn_case.ex
+++ b/template/$PROJECT_NAME$/test/support/conn_case.ex
@@ -20,6 +20,7 @@ defmodule <%= @project_name_camel_case %>.Web.ConnCase do
       # Import conveniences for testing with connections
       use Phoenix.ConnTest
       import <%= @project_name_camel_case %>.Web.Router.Helpers
+      import <%= @project_name_camel_case %>.Factory
 
       # The default endpoint for testing
       @endpoint <%= @project_name_camel_case %>.Web.Endpoint

--- a/template/$PROJECT_NAME$/test/support/data_case.ex
+++ b/template/$PROJECT_NAME$/test/support/data_case.ex
@@ -22,6 +22,7 @@ defmodule <%= @project_name_camel_case %>.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import <%= @project_name_camel_case %>.DataCase
+      import <%= @project_name_camel_case %>.Factory
     end
   end
 

--- a/template/$PROJECT_NAME$/test/support/factory.ex
+++ b/template/$PROJECT_NAME$/test/support/factory.ex
@@ -1,0 +1,11 @@
+defmodule <%= @project_name_camel_case %>.Factory do
+  use ExMachina.Ecto, repo: <%= @project_name_camel_case %>.Repo
+
+  def user_factory do
+    %<%= @project_name_camel_case %>.Account.User{
+      name: sequence(:name, &"user-#{&1}"),
+      email: sequence(:email, &"email-#{&1}@example.com"),
+      password_hash: "password_hash"
+    }
+  end
+end

--- a/template/$PROJECT_NAME$/test/test_helper.exs
+++ b/template/$PROJECT_NAME$/test/test_helper.exs
@@ -2,3 +2,4 @@ ExUnit.start()
 
 Ecto.Adapters.SQL.Sandbox.mode(<%= @project_name_camel_case %>.Repo, :manual)
 
+{:ok, _} = Application.ensure_all_started(:ex_machina)


### PR DESCRIPTION
Adds ex_machina.

I tried using the new generated tests methods of defining the fixtures in the test files themselves, but it just feels so cumbersome compared to having a central repository for fixture data and a super clean api for accessing them and modifying relevant properties on the fly.