### PR TITLE
Remove references to account_users

### DIFF
--- a/template/$PROJECT_NAME$/lib/$PROJECT_NAME$/account/user.ex
+++ b/template/$PROJECT_NAME$/lib/$PROJECT_NAME$/account/user.ex
@@ -4,7 +4,7 @@ defmodule <%= @project_name_camel_case %>.Account.User do
   alias <%= @project_name_camel_case %>.Account.User
 
 
-  schema "account_users" do
+  schema "users" do
     field :email, :string
     field :name, :string
 

--- a/template/$PROJECT_NAME$/priv/repo/migrations/20170604172242_create_user.exs
+++ b/template/$PROJECT_NAME$/priv/repo/migrations/20170604172242_create_user.exs
@@ -10,6 +10,6 @@ defmodule <%= @project_name_camel_case %>.Repo.Migrations.Create<%= @project_nam
       timestamps()
     end
 
-    create unique_index(:account_users, [:email])
+    create unique_index(:users, [:email])
   end
 end

--- a/template/$PROJECT_NAME$/priv/repo/migrations/20170713231425_create_user_token.exs
+++ b/template/$PROJECT_NAME$/priv/repo/migrations/20170713231425_create_user_token.exs
@@ -3,7 +3,7 @@ defmodule <%= @project_name_camel_case %>.Repo.Migrations.Create<%= @project_nam
 
   def change do
     create table(:user_tokens) do
-      add :user_id, references(:account_users, on_delete: :delete_all)
+      add :user_id, references(:users, on_delete: :delete_all)
       add :token, :string, null: false
       add :type, :string, null: false
 


### PR DESCRIPTION
changed the User schema to point to the "users" table so the migrations need to point there as well.